### PR TITLE
comparison of 0 > unsigned expression is always false

### DIFF
--- a/src/serial.c
+++ b/src/serial.c
@@ -151,7 +151,7 @@ int ser_get_control_lines(int fd)
 
 int ser_set_control_lines(int fd, int state)
 {
-  unsigned int status;
+  int status;
 
 
   if (0 > (status = ser_get_control_lines(fd))) {


### PR DESCRIPTION
 [-Wtautological-compare]

int vs unsigned int.