### PR TITLE
use NULL ip address for ip232 server

### DIFF
--- a/src/ip232.c
+++ b/src/ip232.c
@@ -93,7 +93,7 @@ int ip232_init_conn(modem_config *cfg)
   LOG_ENTER();
   LOG(LOG_INFO, "Opening ip232 device");
   port = atoi(cfg->dce_data.tty);
-  rc = ip_init_server_conn("", port);
+  rc = ip_init_server_conn(NULL, port);
   if (rc < 0) {
     ELOG(LOG_FATAL, "Could not initialize ip232 server socket");
     exit(-1);


### PR DESCRIPTION
inet_addr("") is treated as 0xffffffff (INADDR_BROADCAST) which probably isn't what you want.