### PR TITLE
Fix spaces in phonebook number lookup

### DIFF
--- a/src/phone_book.c
+++ b/src/phone_book.c
@@ -21,6 +21,7 @@ int pb_add(char *from, char *to)
     strncpy(phone_book[size][0], from, sizeof(phone_book[size][0]));
     strncpy(phone_book[size][1], to, sizeof(phone_book[size][1]));
     size++;
+    LOG(LOG_INFO, "Phonebook add for '%s': '%s'", from, to);
     LOG_EXIT();
     return 0;
   }
@@ -33,6 +34,14 @@ char *pb_search(char *number)
   int i = 0;
 
   LOG_ENTER();
+  // Remove spaces in phonebook entries, shifts characters left including null terminator
+  for(int i = 0; i < strlen(number)+1; i++) {
+    if(number[i] == ' ') {
+      for(int j = i; j < strlen(number)+1; j++)
+        number[j] = number[j+1];
+    }
+  }
+
   for (i = 0; i < size; i++) {
     if (strcmp(phone_book[i][0], number) == 0) {
 


### PR DESCRIPTION
This patch fixes issues where a dialed number may contain any number of spaces.  Spaces are removed by shifting the next character over until it reaches the null terminator to end the string.